### PR TITLE
Relationships involving instances and reasoning support

### DIFF
--- a/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/OntologyLoader.java
+++ b/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/OntologyLoader.java
@@ -229,6 +229,27 @@ public interface OntologyLoader {
     Collection<IRI> getRelatedChildTerms(IRI entityIRI);
 
 
+    /**
+     * Returns related individuals for a given individual IRI.
+     *
+     * @return the relationship IRI and the set of related terms
+     */
+    Map<IRI, Collection<IRI>> getRelatedIndividuals(IRI entityIRI);
+
+    /**
+     * Returns related individuals to a given class.
+     *
+     * @return the relationship IRI and the set of related classes
+     */
+    Map<IRI, Collection<IRI>> getRelatedIndividualsToClass(IRI entityIRI);
+
+
+    /**
+     * Returns related classes to a given individual.
+     *
+     * @return the relationship IRI and the set of related terms
+     */
+    Map<IRI, Collection<IRI>> getRelatedClassesToIndividual(IRI entityIRI);
 
 
 


### PR DESCRIPTION
1) Instead of calling the dubious instance.getTypes(), OLS now accesses the reasoner directly.
2) On top of relationships between classes (C sub R some D), we now support relationships between
  * Classes and instances (C sub R some {i})
  * Instances and classes (i:R some C)
  * Instances (<i,R,i2>, i:R value i2)