### PR TITLE
OLS relationships (revised)

### DIFF
--- a/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/AbstractOWLOntologyLoader.java
+++ b/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/AbstractOWLOntologyLoader.java
@@ -541,12 +541,14 @@ AbstractOWLOntologyLoader extends Initializable implements OntologyLoader {
     }
 
     private void indexRelationsFromExistentialRestrictionsToNominals(Map<IRI, Collection<IRI>> instanceRelations, OWLObjectOneOf ce, OWLObjectProperty p) {
-        for(OWLIndividual i: ce.getIndividuals()) {
-            if(i.isNamed()) {
-                if(!instanceRelations.containsKey(p.getIRI())) {
-                    instanceRelations.put(p.getIRI(),new HashSet<>());
+        if(ce.getIndividuals().size()==1) { // If there is more than one, we cannot assume a relationship.
+            for (OWLIndividual i : ce.getIndividuals()) {
+                if (i.isNamed()) {
+                    if (!instanceRelations.containsKey(p.getIRI())) {
+                        instanceRelations.put(p.getIRI(), new HashSet<>());
+                    }
+                    instanceRelations.get(p.getIRI()).add(i.asOWLNamedIndividual().getIRI());
                 }
-                instanceRelations.get(p.getIRI()).add(i.asOWLNamedIndividual().getIRI());
             }
         }
     }

--- a/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/OntologyLoader.java
+++ b/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/OntologyLoader.java
@@ -229,6 +229,27 @@ public interface OntologyLoader {
     Collection<IRI> getRelatedChildTerms(IRI entityIRI);
 
 
+    /**
+     * Returns related individuals for a given individual IRI.
+     *
+     * @return the relationship IRI and the set of related terms
+     */
+    Map<IRI, Collection<IRI>> getRelatedIndividuals(IRI entityIRI);
+
+    /**
+     * Returns related individuals to a given class.
+     *
+     * @return the relationship IRI and the set of related classes
+     */
+    Map<IRI, Collection<IRI>> getRelatedIndividualsToClass(IRI entityIRI);
+
+
+    /**
+     * Returns related classes to a given individual.
+     *
+     * @return the relationship IRI and the set of related terms
+     */
+    Map<IRI, Collection<IRI>> getRelatedClassesToIndividual(IRI entityIRI);
 
 
 


### PR DESCRIPTION
Instead of calling the dubious instance.getTypes(), OLS now accesses the reasoner directly.
On top of relationships between classes (C sub R some D), we now support relationships between
Classes and instances (C sub R some {i})
Instances and classes (i:R some C)
Instances (<i,R,i2>, i:R value i2)