### PR TITLE
Correct final search page record count (fix #279); fix 'Prev' navigation

### DIFF
--- a/ols-web/src/main/resources/static/js/ols-adv-search.js
+++ b/ols-web/src/main/resources/static/js/ols-adv-search.js
@@ -97,17 +97,15 @@ function solrSearch(queryTerm) {
         });
 }
 
-
 function clickPrev() {
     if (! $( ".prev-button" ).first().hasClass( "disabled" )) {
-        var start = $('.start-display').first().text() - 11;
+        var start = Math.max($('.start-display').first().text() - 11, 0);
         $('#start').val(start);
-        $('#filter_form').submit();
+        $('#filter_form').removeAttr('onsubmit').submit();
     }
 }
 
 function clickNext() {
-
     if (!$( ".next-button" ).first().hasClass( "disabled" )) {
         var end = $('.end-display').first().text();
         $('#start').val(end);
@@ -120,7 +118,8 @@ function processData(data) {
 
     // render results stats and pagination
     var start = data.response.start;
-    var end = data.response.numFound > 10 ? start + 10 : data.response.numFound;
+    // var end = data.response.numFound > 10 ? start + 10 : data.response.numFound;
+    var end = start + ((data.response.numFound - start) >= 10 ? 10 : ((data.response.numFound - start) % 10));
     var total = data.response.numFound;
 
     if (total == 0) {

--- a/ols-web/src/main/resources/static/js/ols-adv-search.js
+++ b/ols-web/src/main/resources/static/js/ols-adv-search.js
@@ -118,7 +118,6 @@ function processData(data) {
 
     // render results stats and pagination
     var start = data.response.start;
-    // var end = data.response.numFound > 10 ? start + 10 : data.response.numFound;
     var end = start + ((data.response.numFound - start) >= 10 ? 10 : ((data.response.numFound - start) % 10));
     var total = data.response.numFound;
 


### PR DESCRIPTION
This is supposed to fix the incorrect record count which appears on the final page of results after any search (unless the number of results is a multiple of ten, since ten results per page are displayed). The current page always states that there are 10 results, e.g. "Showing 21 to 30 of 23 results". So the fix gives "Showing 21 to 23 of 23 results". This commit also includes a fix to "Prev" button functionality, the current online version of which actually takes you right back to the first page of results, wherever you start from. So now it just goes back to the previous batch of 10, which is a lot more natural and less frustrating. Just as a general comment, the navigability of large result sets could be enhanced a bit. Anyway, the fixes themselves are utterly trivial one-liners, so should be easy enough to verify.