### PR TITLE
Update the YamlConfigParser to work if no ontologies are defined 

### DIFF
--- a/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/config/YamlConfigParser.java
+++ b/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/config/YamlConfigParser.java
@@ -49,7 +49,9 @@ public class YamlConfigParser {
 
 
         ArrayList<LinkedHashMap> ontologies = (ArrayList<LinkedHashMap>)linkedHashMap.get("ontologies");
-
+        if(ontologies ==null){
+            return documentLoadingServices;
+        }
         for (LinkedHashMap ontology : ontologies) {
 
             boolean _isObo = isObo;


### PR DESCRIPTION
Currently if no ontologies are defined a NPE is thrown. This can easily mitigated by an additional null check. The response of the `getDocument()` method stays the same. 
