### PR TITLE
Hopefully fix the issue of ontologies not updating

### DIFF
--- a/ols-apps/ols-loading-app/src/test/java/uk/ac/ebi/spot/ols/FileUpdateTests.java
+++ b/ols-apps/ols-loading-app/src/test/java/uk/ac/ebi/spot/ols/FileUpdateTests.java
@@ -34,7 +34,7 @@ public class FileUpdateTests {
             e.printStackTrace();
         }
 
-        System.out.println(status.isNew());
+        System.out.println(status.getLatestHash());
 
 
     }

--- a/ols-core/src/main/java/uk/ac/ebi/spot/ols/model/OntologyDocument.java
+++ b/ols-core/src/main/java/uk/ac/ebi/spot/ols/model/OntologyDocument.java
@@ -34,6 +34,7 @@ public class OntologyDocument {
     private String localPath;
 
     private String version;
+    private String fileHash;
 
 
     private int numberOfTerms;
@@ -43,6 +44,7 @@ public class OntologyDocument {
     private OntologyResourceConfig config;
 
     public OntologyDocument(String ontologyId, Date updated, Status status, String message, String localPath,
+                            String fileHash,
                             int numberOfTerms, int numberOfProperties, int numberOfIndividuals,
                             OntologyResourceConfig config) {
         this.ontologyId = ontologyId;
@@ -50,6 +52,7 @@ public class OntologyDocument {
         this.status = status;
         this.message = message;
         this.localPath = localPath;
+        this.fileHash = fileHash;
         this.numberOfTerms = numberOfTerms;
         this.numberOfProperties = numberOfProperties;
         this.numberOfIndividuals = numberOfIndividuals;
@@ -62,7 +65,7 @@ public class OntologyDocument {
     }
 
     public OntologyDocument(String ontologyId, OntologyResourceConfig config) {
-        this(ontologyId, new Date(), Status.NOTLOADED, "No ontology loaded", null, 0,
+        this(ontologyId, new Date(), Status.NOTLOADED, "No ontology loaded", null,"", 0,
                 0,0, config);
     }
 
@@ -152,5 +155,13 @@ public class OntologyDocument {
 
     public void setLocalPath(String localPath) {
         this.localPath = localPath;
+    }
+
+    public String getFileHash() {
+        return fileHash;
+    }
+
+    public void setFileHash(String fileHash) {
+        this.fileHash = fileHash;
     }
 }

--- a/ols-core/src/main/java/uk/ac/ebi/spot/ols/service/FileUpdatingService.java
+++ b/ols-core/src/main/java/uk/ac/ebi/spot/ols/service/FileUpdatingService.java
@@ -81,7 +81,7 @@ public class FileUpdatingService {
             try {
                 status = fileUpdateService.getFile(config.getNamespace(), config.getFileLocation());
                 document.setLocalPath(status.getFile().getCanonicalPath());
-                if (force || status.isNew() || wasFailing) {
+                if (force || !document.getFileHash().equals(status.getLatestHash()) || wasFailing) {
                     document.setStatus(Status.TOLOAD);
                     document.setMessage("");
                 }
@@ -113,6 +113,7 @@ public class FileUpdatingService {
                 getLog().info("Status of " + document.getOntologyId() + " is " + document.getStatus());
 
                 document.setUpdated(new Date());
+                document.setFileHash(status.getLatestHash());
                 ontologyRepositoryService.update(document);
                 latch.countDown();
             }

--- a/ols-core/src/main/java/uk/ac/ebi/spot/ols/util/FileUpdater.java
+++ b/ols-core/src/main/java/uk/ac/ebi/spot/ols/util/FileUpdater.java
@@ -120,23 +120,19 @@ public class FileUpdater {
 
                 // create one for the downloaded file
 
-                // if they are the same, the file hasn't changed
-                if (latestChecksum.equals(downloadChecksum)) {
-                    return new FileStatus(latestFile, false);
-                }
-                else {
+                // if they are different, the file has changed
+                if (!latestChecksum.equals(downloadChecksum)) {
                     // if they are different, copy the downloaded file to the latest file
                     FileCopyUtils.copy(downloadFile, latestFile );
                     // update the latest file checksum
                     writeChecksum(latestFileChecksum, downloadChecksum);
-                    return new FileStatus(latestFile, true);
                 }
             }
             else {
                 FileCopyUtils.copy(downloadFile, latestFile );
                 writeChecksum(latestFileChecksum, downloadChecksum);
-                return new FileStatus(latestFile, true);
             }
+            return new FileStatus(latestFile, downloadChecksum);
 
         } catch (Exception e) {
             throw new FileUpdateServiceException("Failed to download file: " + e.getMessage(), e);
@@ -240,20 +236,19 @@ public class FileUpdater {
 
     public class FileStatus {
         private File file;
-        private boolean isNew;
+        private String latestHash;
 
-
-        public FileStatus(File latestFile, boolean b) {
+        public FileStatus(File latestFile, String latestHash) {
             this.file = latestFile;
-            this.isNew = b;
+            this.latestHash = latestHash;
         }
 
         public File getFile() {
             return file;
         }
 
-        public boolean isNew() {
-            return isNew;
+        public String getLatestHash() {
+            return latestHash;
         }
     }
 


### PR DESCRIPTION
The hash of the ontology is now updated in the database, only AFTER the
ontology has been loaded successfully (unlike the download hash file
which is updated regardless).  If this hash does not match a downloaded
ontology, the ontology is reloaded.