### PR TITLE
Upgraded MongoDB Java Driver from 2.14.3 to the newest version 3.12.3

### DIFF
--- a/ols-dependencies/pom.xml
+++ b/ols-dependencies/pom.xml
@@ -21,7 +21,7 @@
         <elk.version>0.4.2</elk.version>
         <commons-cli.version>1.2</commons-cli.version>
         <springboot.maven>1.2.5.RELEASE</springboot.maven>
-        <mongodb.version>2.14.3</mongodb.version>
+        <mongodb.version>3.12.3</mongodb.version>
         <junit.jupiter.version>5.4.0</junit.jupiter.version>       
     </properties>
 

--- a/ols-mongo/src/main/java/uk/ac/ebi/spot/ols/service/MongoOntologyRepositoryService.java
+++ b/ols-mongo/src/main/java/uk/ac/ebi/spot/ols/service/MongoOntologyRepositoryService.java
@@ -5,19 +5,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.AggregationResults;
-import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
-import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Component;
-
-import com.mongodb.MongoTimeoutException;
 
 import uk.ac.ebi.spot.ols.exception.OntologyRepositoryException;
 import uk.ac.ebi.spot.ols.model.OntologyDocument;
 import uk.ac.ebi.spot.ols.model.Status;
 import uk.ac.ebi.spot.ols.repository.mongo.MongoOntologyRepository;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 import java.util.Date;
 import java.util.List;
 
@@ -93,54 +86,20 @@ public class MongoOntologyRepositoryService implements OntologyRepositoryService
 
     @Override
     public int getNumberOfTerms() {
-        Aggregation agg =
-                Aggregation.newAggregation(
-                        group("ANYTHING").sum("numberOfTerms").as("total"),
-                        project("total")
-                );
-        //Convert the aggregation result into a List
-        AggregationResults<AggregateResult> groupResults
-                = mongoTemplate.aggregate(agg, "olsadmin", AggregateResult.class);
-        AggregateResult result = groupResults.getUniqueMappedResult();
-        return result.getTotal();
+        List<OntologyDocument> documents = repositoryService.findAll(new Sort("numberOfTerms"));
+        return documents.stream().mapToInt(OntologyDocument::getNumberOfTerms).sum();
     }
 
     @Override
     public int getNumberOfProperties() {
-        Aggregation agg =
-                Aggregation.newAggregation(
-                        group("ANYTHING").sum("numberOfProperties").as("total"),
-                        project("total")
-                );
-        //Convert the aggregation result into a List
-        AggregationResults<AggregateResult> groupResults
-                = mongoTemplate.aggregate(agg, "olsadmin", AggregateResult.class);
-        AggregateResult result = groupResults.getUniqueMappedResult();
-        return result.getTotal();
-
+        List<OntologyDocument> documents = repositoryService.findAll(new Sort("numberOfProperties"));
+        return documents.stream().mapToInt(OntologyDocument::getNumberOfProperties).sum();
     }
 
     @Override
     public int getNumberOfIndividuals() {
-        Aggregation agg =
-                Aggregation.newAggregation(
-                        group("ANYTHING").sum("numberOfIndividuals").as("total"),
-                        project("total")
-                );
-        //Convert the aggregation result into a List
-        AggregationResults<AggregateResult> groupResults
-                = mongoTemplate.aggregate(agg, "olsadmin", AggregateResult.class);
-        AggregateResult result = groupResults.getUniqueMappedResult();
-        return result.getTotal();
+        List<OntologyDocument> documents = repositoryService.findAll(new Sort("numberOfIndividuals"));
+        return documents.stream().mapToInt(OntologyDocument::getNumberOfIndividuals).sum();
     }
-
-    private class AggregateResult {
-        int total;
-
-        public int getTotal() {
-            return total;
-        }
-    }
-
 
 }

--- a/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/AbstractOWLOntologyLoader.java
+++ b/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/AbstractOWLOntologyLoader.java
@@ -1159,7 +1159,7 @@ AbstractOWLOntologyLoader extends Initializable implements OntologyLoader {
                         addClassLabel(owlEntityIRI, evaluateLabelAnnotationValue(
                         		owlEntity, annotationAssertionAxiom.getValue()).get());
                     } else {
-                        getLogger().warn("Found multiple labels for class" + owlEntityIRI.toString());
+                        getLogger().warn("Found multiple labels for class " + owlEntityIRI.toString());
                         // if english, overide previous label
                         if (isEnglishLabel(annotationAssertionAxiom.getValue())) {
                             addClassLabel(owlEntityIRI, evaluateLabelAnnotationValue(


### PR DESCRIPTION
Now it is possible to run OLS with a newer version of the MongoDB.