### PR TITLE
Fix for the issue of owl:Thing not being labelled as a Root in neo4j

### DIFF
--- a/ols-neo4j/src/main/java/uk/ac/ebi/spot/ols/loader/BatchNeo4JIndexer.java
+++ b/ols-neo4j/src/main/java/uk/ac/ebi/spot/ols/loader/BatchNeo4JIndexer.java
@@ -319,13 +319,17 @@ public class BatchNeo4JIndexer implements OntologyIndexer {
             inserter.createRelationship( node, mergedNode, refersTo, null);
 
             addParentAndRelatedParentNodesWithRelationships(inserter, loader, nodeMap, classIri, node);
-            
+        }
+
+        for (IRI classIri : loader.getAllClasses()) {
+
+            Long node = nodeMap.get(classIri.toString());
 
             indexRelatedNodes(inserter, loader, nodeMap, classIri, node);
 
             indexRelatedIndividuals(node, loader.getRelatedIndividualsToClass(classIri), inserter,
             		loader,nodeMap, new LinkedList<Label>(Arrays.asList(
-            				instanceLabel, nodeOntologyLabel, _instanceLabel)));
+                            instanceLabel, nodeOntologyLabel, _instanceLabel)));
         }
     }
 


### PR DESCRIPTION
An axiom subClassOf (someproperty some owl:Thing) could cause the owl:Thing
node to be created through the code path for "related nodes", which does
not set the Root label.

Failing example:

```
<?xml version="1.0"?>
<rdf:RDF xmlns="http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#"
     xml:base="http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:xml="http://www.w3.org/XML/1998/namespace"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
    <owl:Ontology rdf:about="http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18"/>
    


    <!-- 
    ///////////////////////////////////////////////////////////////////////////////////////
    //
    // Object Properties
    //
    ///////////////////////////////////////////////////////////////////////////////////////
     -->

    


    <!-- http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#testprop -->

    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#testprop">
        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
    </owl:ObjectProperty>
    


    <!-- 
    ///////////////////////////////////////////////////////////////////////////////////////
    //
    // Classes
    //
    ///////////////////////////////////////////////////////////////////////////////////////
     -->

    


    <!-- http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#entity -->

    <owl:Class rdf:about="http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#entity"/>
    


    <!-- http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#test -->

    <owl:Class rdf:about="http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#test">
        <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#entity"/>
        <rdfs:subClassOf>
            <owl:Restriction>
                <owl:onProperty rdf:resource="http://www.semanticweb.org/james/ontologies/2020/4/untitled-ontology-18#testprop"/>
                <owl:someValuesFrom rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
            </owl:Restriction>
        </rdfs:subClassOf>
    </owl:Class>
</rdf:RDF>



<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
```

IMO the neo4j indexer is in need of refactoring to make it more explicit which
code paths are responsible for creating nodes, but meanwhile this minimal
fix simply ensures that all nodes are created before handling related nodes.
