### PR TITLE
Use full IRI in getOWLAnnotationValueAsString if short form is empty …

### DIFF
--- a/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/AbstractOWLOntologyLoader.java
+++ b/ontology-tools/src/main/java/uk/ac/ebi/spot/ols/loader/AbstractOWLOntologyLoader.java
@@ -1355,8 +1355,10 @@ AbstractOWLOntologyLoader extends Initializable implements OntologyLoader {
 
         if (value instanceof IRI) {
             Optional<String> shortForm= extractShortForm((IRI) value);
-            if ( shortForm.isPresent()) {
+            if ( shortForm.isPresent() && !shortForm.get().isEmpty()) {
                 return Optional.of(shortForm.get());
+            } else {
+                return Optional.of( ((IRI) value).toString() );
             }
         }
         else if (value instanceof OWLLiteral) {


### PR DESCRIPTION
…(fixes #404)