### PR TITLE
Make docker compose setup self contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,29 +62,7 @@ more information http://www.ebi.ac.uk/ols/docs/installation-guide
 
 The preferred method of deployment for OLS is using Docker. If you would like to deploy **the entire OntoTools stack** (OLS, OxO, and ZOOMA), check out the [OntoTools Docker Config](https://github.com/EBISPOT/ontotools-docker-config) repository. If you would like to deploy **OLS only**, read on.
 
-First, create the necessary volumes:
-
-    docker volume create --name=ols-neo4j-data
-    docker volume create --name=ols-mongo-data
-    docker volume create --name=ols-solr-data
-    docker volume create --name=ols-downloads
-
-Then, start solr and mongodb only:
-
-    docker-compose up -d solr mongo
-
-Then, adjust the configuration YAML files in the `config` directory as required,
-and load the configuration into the Mongo database using the config loader:
-
-    docker run --net=host -v $(pwd)/config:/config ebispot/ols-config-importer:stable
-
-Then, run the indexer:
-
-    docker run --net=host -v ols-neo4j-data:/mnt/neo4j -v ols-downloads:/mnt/downloads ebispot/ols-indexer:stable
-
-Finally, start the OLS webserver:
-
-    docker-compose up -d ols-web
+    docker-compose up
 
 You should now be able to access a populated OLS instance at `http://localhost:8080`.
 
@@ -96,7 +74,7 @@ built using the Dockerfiles in this repository.
 
     docker build -f ols-apps/ols-config-importer/Dockerfile -t ols-config-importer .
     docker build -f ols-apps/ols-indexer/Dockerfile -t ols-indexer .
-  
+
 
 
 ## Building OLS manually

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,13 +18,37 @@ services:
           - ols-mongo-data:/data/db
       command:
           - mongod
+    ols-config-importer:
+      build:
+          context: .
+          dockerfile: ./ols-apps/ols-config-importer/Dockerfile
+      environment:
+        - spring.data.mongodb.host=mongo
+      volumes:
+        - ./config:/config
+      depends_on: ["mongo"]
+      restart: on-failure:2
+
+    ols-indexer:
+      build:
+          context: .
+          dockerfile: ./ols-apps/ols-indexer/Dockerfile
+      environment:
+        - spring.data.solr.host=http://solr:8983/solr
+        - spring.data.mongodb.host=mongo
+      volumes:
+        - ols-neo4j-data:/mnt/neo4j
+        - ols-downloads:/mnt/downloads
+      depends_on:
+        ols-config-importer:
+          condition: service_completed_successfully
     ols-web:
       build:
           context: .
           dockerfile: ols-web/Dockerfile
       depends_on:
-        - solr
-        - mongo
+        ols-indexer:
+          condition: service_completed_successfully
       links:
         - solr
         - mongo
@@ -44,16 +68,11 @@ services:
         - OLS_HOME=/mnt/
       volumes:
         - ols-neo4j-data:/mnt/neo4j
-        - ols-downloads:/mnt/downloads        
+        - ols-downloads:/mnt/downloads
       ports:
       - 8080:8080
 volumes:
     ols-solr-data:
-        external: true
     ols-mongo-data:
-        external: true
     ols-neo4j-data:
-        external: true
     ols-downloads:
-        external: true
-


### PR DESCRIPTION
Adds the ols-config-importer and the ols-indexer to the docker compose setup.
Instead of the multi-step method, a single `docker-compose up` is all that is needed.
See https://github.com/EBISPOT/OLS/issues/575.