### PR TITLE
Add Docker BuildKit Maven caches.

### DIFF
--- a/ols-apps/ols-config-importer/Dockerfile
+++ b/ols-apps/ols-config-importer/Dockerfile
@@ -2,8 +2,8 @@
 FROM maven:3.6-jdk-8 AS build
 RUN mkdir /opt/ols
 COPY . /opt/ols/ 
-COPY build-fix/. /root/.m2/repository/
-RUN cd /opt/ols && ls && mvn clean package -DskipTests
+COPY build-fix/. /root/build-fix
+RUN --mount=type=cache,target=/root/.m2 mkdir -p /root/.m2/repository && cp -r /root/build-fix/* /root/.m2/repository/ && cd /opt/ols && ls && mvn clean package -DskipTests
 
 FROM openjdk:8-jre-alpine
 RUN apk add bash

--- a/ols-apps/ols-indexer/Dockerfile
+++ b/ols-apps/ols-indexer/Dockerfile
@@ -1,9 +1,8 @@
-
 FROM maven:3.6-jdk-8 AS build
 RUN mkdir /opt/ols
 COPY . /opt/ols/ 
-COPY build-fix/. /root/.m2/repository/
-RUN cd /opt/ols && ls && mvn clean package -DskipTests
+COPY build-fix/. /root/build-fix
+RUN --mount=type=cache,target=/root/.m2 mkdir -p /root/.m2/repository && cp -r /root/build-fix/* /root/.m2/repository/ && cd /opt/ols && ls && mvn clean package -DskipTests
 
 FROM openjdk:8-jre-alpine
 RUN apk add bash

--- a/ols-apps/ols-indexer/src/main/java/uk/ac/ebi/spot/ols/LoadingApplication.java
+++ b/ols-apps/ols-indexer/src/main/java/uk/ac/ebi/spot/ols/LoadingApplication.java
@@ -173,7 +173,7 @@ public class LoadingApplication implements CommandLineRunner {
         else {
             // otherwise load everything set TOLOAD
             for (OntologyDocument document : ontologyRepositoryService.getAllDocumentsByStatus(Status.TOLOAD)) {
-                // try {
+                try {
                     boolean loadResult = ontologyIndexingService.indexOntologyDocument(document);
                     if (loadResult)
                         updatedOntologies.add(document.getOntologyId());
@@ -181,14 +181,14 @@ public class LoadingApplication implements CommandLineRunner {
                         haserror = true;
                         failingOntologies.put(document.getOntologyId(), "An error occurred. Check logs.");
                     }
-                // } catch (Throwable t) {
-                // 	logger.error("Application failed creating indexes for " + document.getOntologyId() + ": " +
-                //             t.getMessage(), t);
-                //     exceptions.append(t.getMessage());
-                //     exceptions.append("\n");
-                //     haserror = true;
-                //     failingOntologies.put(document.getOntologyId(),t.getMessage());
-                // }
+                 } catch (Throwable t) {
+                 	logger.error("Application failed creating indexes for " + document.getOntologyId() + ": " +
+                             t.getMessage(), t);
+                     exceptions.append(t.getMessage());
+                     exceptions.append("\n");
+                     haserror = true;
+                     failingOntologies.put(document.getOntologyId(),t.getMessage());
+                 }
             }
         }
 

--- a/ols-web/Dockerfile
+++ b/ols-web/Dockerfile
@@ -1,9 +1,8 @@
-
 FROM maven:3.6-jdk-8 AS build
 RUN mkdir /opt/ols
 COPY . /opt/ols/ 
-COPY build-fix/. /root/.m2/repository/
-RUN cd /opt/ols && ls && mvn clean package -DskipTests
+COPY build-fix/. /root/build-fix
+RUN --mount=type=cache,target=/root/.m2 mkdir -p /root/.m2/repository && cp -r /root/build-fix/* /root/.m2/repository/ && cd /opt/ols && ls && mvn clean package -DskipTests
 
 FROM openjdk:8-jre-alpine
 RUN apk add bash


### PR DESCRIPTION
See https://github.com/EBISPOT/OLS/issues/586.
Requires Docker BuildKit to be enabled, but with such a massive build time reduction I think that is worth it even if you don't have it enabled yet.