### PR TITLE
Drastically reduce Maven log output

### DIFF
--- a/.github/workflows/ols-release.yml
+++ b/.github/workflows/ols-release.yml
@@ -30,7 +30,7 @@ jobs:
           mvn -B release:update-versions -DreleaseVersion=${{ steps.versionNumber.outputs.value }} -DdevelopmentVersion=${{ steps.versionNumber.outputs.value }}-SNAPSHOT
           mvn versions:set -DremoveSnapshot -DgenerateBackupPoms=false -DprocessAllModules=true
       - name: Build OLS
-        run: mvn clean package -DskipTests
+        run: mvn -B clean package -DskipTests
       - name: Create archive
         run: |
           mkdir ols_jars_${{ github.ref_name }}

--- a/ols-apps/ols-config-importer/Dockerfile
+++ b/ols-apps/ols-config-importer/Dockerfile
@@ -3,7 +3,8 @@ FROM maven:3.6-jdk-8 AS build
 RUN mkdir /opt/ols
 COPY . /opt/ols/ 
 COPY build-fix/. /root/.m2/repository/
-RUN cd /opt/ols && ls && mvn clean package -DskipTests
+ENV MAVEN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+RUN cd /opt/ols && ls && mvn clean package -B -DskipTests
 
 FROM openjdk:8-jre-alpine
 RUN apk add bash

--- a/ols-apps/ols-indexer/Dockerfile
+++ b/ols-apps/ols-indexer/Dockerfile
@@ -3,7 +3,8 @@ FROM maven:3.6-jdk-8 AS build
 RUN mkdir /opt/ols
 COPY . /opt/ols/ 
 COPY build-fix/. /root/.m2/repository/
-RUN cd /opt/ols && ls && mvn clean package -DskipTests
+ENV MAVEN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+RUN cd /opt/ols && ls && mvn clean package -B -DskipTests
 
 FROM openjdk:8-jre-alpine
 RUN apk add bash

--- a/ols-apps/ols-indexer/src/main/java/uk/ac/ebi/spot/ols/LoadingApplication.java
+++ b/ols-apps/ols-indexer/src/main/java/uk/ac/ebi/spot/ols/LoadingApplication.java
@@ -173,7 +173,7 @@ public class LoadingApplication implements CommandLineRunner {
         else {
             // otherwise load everything set TOLOAD
             for (OntologyDocument document : ontologyRepositoryService.getAllDocumentsByStatus(Status.TOLOAD)) {
-                // try {
+                try {
                     boolean loadResult = ontologyIndexingService.indexOntologyDocument(document);
                     if (loadResult)
                         updatedOntologies.add(document.getOntologyId());
@@ -181,14 +181,14 @@ public class LoadingApplication implements CommandLineRunner {
                         haserror = true;
                         failingOntologies.put(document.getOntologyId(), "An error occurred. Check logs.");
                     }
-                // } catch (Throwable t) {
-                // 	logger.error("Application failed creating indexes for " + document.getOntologyId() + ": " +
-                //             t.getMessage(), t);
-                //     exceptions.append(t.getMessage());
-                //     exceptions.append("\n");
-                //     haserror = true;
-                //     failingOntologies.put(document.getOntologyId(),t.getMessage());
-                // }
+                 } catch (Throwable t) {
+                 	logger.error("Application failed creating indexes for " + document.getOntologyId() + ": " +
+                             t.getMessage(), t);
+                     exceptions.append(t.getMessage());
+                     exceptions.append("\n");
+                     haserror = true;
+                     failingOntologies.put(document.getOntologyId(),t.getMessage());
+                 }
             }
         }
 

--- a/ols-web/Dockerfile
+++ b/ols-web/Dockerfile
@@ -3,7 +3,8 @@ FROM maven:3.6-jdk-8 AS build
 RUN mkdir /opt/ols
 COPY . /opt/ols/ 
 COPY build-fix/. /root/.m2/repository/
-RUN cd /opt/ols && ls && mvn clean package -DskipTests
+ENV MAVEN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+RUN cd /opt/ols && ls && mvn -B clean package -DskipTests
 
 FROM openjdk:8-jre-alpine
 RUN apk add bash


### PR DESCRIPTION
Right now it is impossible to debug most build errors because Maven is run in interactive mode, which spams thousands of lines of progress indicators into the log file.
This makes it really hard to find the problematic lines as it is but even worse is that Docker BuildKit will limit log size to 1 MB at which point it just stops logging.
While there are in theory options to increase log size, those did not work in my testing and also the far better fix is to correctly set Maven to batch mode, which is intended for noninteractive use like Docker and GitHub actions.
Also, this pull request sets the Maven transfer log level to warn, so that lines like "Downloading from X: Y" are hidden unless there is a problem.

For example, currently, just one single dependency, jcl-over-slf4j, causes the output shown below (note that it scrolls far to the right).
Attached to this PR are also the log files from before (clipped at 1 MB) and after (136 k).

```
#12 17.30 Downloading from neo4j: http://m2.neo4j.org/content/repositories/releases/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21.jar
#12 17.30 Downloading from jcenter-snapshots: https://jcenter.bintray.com/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
#12 17.30 Downloading from jcenter-snapshots: https://jcenter.bintray.com/ch/qos/logback/logback-classic/1.1.7/logback-classic-1.1.7.jar
#12 17.30 Downloading from jcenter-snapshots: https://jcenter.bintray.com/ch/qos/logback/logback-core/1.1.7/logback-core-1.1.7.jar
#12 17.30 Downloading from jcenter-snapshots: https://jcenter.bintray.com/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21.jar
#12 17.30 Downloading from jcenter-snapshots: https://jcenter.bintray.com/org/slf4j/jul-to-slf4j/1.7.21/jul-to-slf4j-1.7.21.jar
#12 17.32 Progress (1): 3.4/41 kB^MProgress (1): 6.0/41 kB^MProgress (1): 8.7/41 kB^MProgress (1): 11/41 kB ^MProgress (1): 14/41 kB^MProgress (1): 17/41 kB^MProgress (1): 19/41 kB^MProgress (1): 22/41 kB^MProgress (1): 25/41 kB^MProgress (1): 27/41 kB^MProgress (1): 30/41 kB^MProgress (1): 33/41 kB^MProgress (1): 35/41 kB^MProgress (1): 38/41 kB^MProgress (1): 41/41 kB^MProgress (1): 41 kB   ^M                   ^MDownloaded from jcenter-snapshots: https://jcenter.bintray.com/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar (41 kB at 821 kB/s)
#12 17.35 Downloading from jcenter-snapshots: https://jcenter.bintray.com/org/slf4j/log4j-over-slf4j/1.7.21/log4j-over-slf4j-1.7.21.jar
#12 17.36 Progress (1): 3.4/4.6 kB^MProgress (1): 4.6 kB    ^MProgress (2): 4.6 kB | 3.3/24 kB^MProgress (2): 4.6 kB | 6.0/24 kB^MProgress (2): 4.6 kB | 8.7/24 kB^MProgress (2): 4.6 kB | 11/24 kB ^MProgress (2): 4.6 kB | 14/24 kB^MProgress (2): 4.6 kB | 17/24 kB^MProgress (2): 4.6 kB | 19/24 kB^MProgress (2): 4.6 kB | 22/24 kB^MProgress (2): 4.6 kB | 24 kB   ^M                            ^MDownloaded from jcenter-snapshots: https://jcenter.bintray.com/org/slf4j/jul-to-slf4j/1.7.21/jul-to-slf4j-1.7.21.jar (4.6 kB at 61 kB/s)
#12 17.38 Progress (2): 24 kB | 3.4/16 kB^MProgress (2): 24 kB | 6.0/16 kB^MProgress (2): 24 kB | 8.7/16 kB^MProgress (3): 24 kB | 8.7/16 kB | 3.4/304 kB^MProgress (3): 24 kB | 8.7/16 kB | 6.0/304 kB^MProgress (3): 24 kB | 8.7/16 kB | 8.7/304 kB^MProgress (4): 24 kB | 8.7/16 kB | 8.7/304 kB | 3.4/471 kB^MProgress (4): 24 kB | 11/16 kB | 8.7/304 kB | 3.4/471 kB ^MProgress (4): 24 kB | 11/16 kB | 8.7/304 kB | 6.0/471 kB^MProgress (4): 24 kB | 11/16 kB | 11/304 kB | 6.0/471 kB ^MProgress (4): 24 kB | 14/16 kB | 11/304 kB | 6.0/471 kB^MProgress (4): 24 kB | 14/16 kB | 11/304 kB | 8.7/471 kB^MProgress (4): 24 kB | 14/16 kB | 14/304 kB | 8.7/471 kB^MProgress (4): 24 kB | 16 kB | 14/304 kB | 8.7/471 kB   ^MProgress (4): 24 kB | 16 kB | 14/304 kB | 11/471 kB ^MProgress (4): 24 kB | 16 kB | 17/304 kB | 11/471 kB^MProgress (4): 24 kB | 16 kB | 17/304 kB | 14/471 kB^MProgress (4): 24 kB | 16 kB | 19/304 kB | 14/471 kB^MProgress (4): 24 kB | 16 kB | 19/304 kB | 17/471 kB^MProgress (4): 24 kB | 16 kB | 19/304 kB | 19/471 kB^M                                                   ^MDownloaded from jcenter-snapshots: https://jcenter.bintray.com/org/slf4j/log4j-over-slf4j/1.7.21/log4j-over-slf4j-1.7.21.jar (24 kB at 275 kB/s)
#12 17.39 Progress (3): 16 kB | 22/304 kB | 19/471 kB^MProgress (3): 16 kB | 25/304 kB | 19/471 kB^MProgress (3): 16 kB | 25/304 kB | 22/471 kB^MProgress (3): 16 kB | 25/304 kB | 25/471 kB^MProgress (3): 16 kB | 27/304 kB | 25/471 kB^MProgress (3): 16 kB | 27/304 kB | 27/471 kB^MProgress (3): 16 kB | 30/304 kB | 27/471 kB^MProgress (3): 16 kB | 30/304 kB | 30/471 kB^MProgress (3): 16 kB | 33/304 kB | 30/471 kB^MProgress (3): 16 kB | 33/304 kB | 33/471 kB^MProgress (3): 16 kB | 35/304 kB | 33/471 kB^MProgress (3): 16 kB | 35/304 kB | 35/471 kB^MProgress (3): 16 kB | 38/304 kB | 35/471 kB^M                                           ^MDownloaded from jcenter-snapshots: https://jcenter.bintray.com/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21.jar (16 kB at 164 kB/s)
#12 17.40 Progress (2): 38/304 kB | 38/471 kB^MProgress (2): 41/304 kB | 38/471 kB^MProgress (2): 41/304 kB | 41/471 kB^MProgress (2): 43/304 kB | 41/471 kB^MProgress (2): 43/304 kB | 43/471 kB^MProgress (2): 46/304 kB | 43/471 kB^MProgress (2): 46/304 kB | 46/471 kB^MProgress (2): 49/304 kB | 46/471 kB^MProgress (2): 49/304 kB | 49/471 kB^MProgress (2): 52/304 kB | 49/471 kB^MProgress (2): 52/304 kB | 52/471 kB^MProgress (2): 54/304 kB | 52/471 kB^MProgress (2): 54/304 kB | 54/471 kB^MProgress (2): 57/304 kB | 54/471 kB^MProgress (2): 57/304 kB | 57/471 kB^MProgress (2): 60/304 kB | 57/471 kB^MProgress (2): 62/304 kB | 57/471 kB^MProgress (2): 65/304 kB | 57/471 kB^MProgress (2): 65/304 kB | 60/471 kB^MProgress (2): 65/304 kB | 62/471 kB^MProgress (2): 68/304 kB | 62/471 kB^MProgress (2): 68/304 kB | 65/471 kB^MProgress (2): 71/304 kB | 65/471 kB^MProgress (2): 74/304 kB | 65/471 kB^MProgress (2): 74/304 kB | 68/471 kB^MProgress (2): 76/304 kB | 68/471 kB^MProgress (2): 76/304 kB | 71/471 kB^MProgress (2): 79/304 kB | 71/471 kB^MProgress (2): 79/304 kB | 74/471 kB^MProgress (2): 82/304 kB | 74/471 kB^MProgress (2): 82/304 kB | 76/471 kB^MProgress (2): 82/304 kB | 79/471 kB^MProgress (2): 84/304 kB | 79/471 kB^MProgress (2): 87/304 kB | 79/471 kB^MProgress (2): 87/304 kB | 82/471 kB^MProgress (2): 90/304 kB | 82/471 kB^MProgress (2): 90/304 kB | 84/471 kB^MProgress (2): 90/304 kB | 87/471 kB^MProgress (2): 92/304 kB | 87/471 kB^MProgress (2): 95/304 kB | 87/471 kB^MProgress (2): 95/304 kB | 90/471 kB^MProgress (2): 95/304 kB | 92/471 kB^MProgress (2): 98/304 kB | 92/471 kB^MProgress (2): 98/304 kB | 95/471 kB^MProgress (2): 101/304 kB | 95/471 kB^MProgress (2): 104/304 kB | 95/471 kB^MProgress (2): 104/304 kB | 98/471 kB^MProgress (2): 104/304 kB | 101/471 kB^MProgress (2): 106/304 kB | 101/471 kB^MProgress (2): 106/304 kB | 104/471 kB^MProgress (2): 109/304 kB | 104/471 kB^MProgress (2): 112/304 kB | 104/471 kB^MProgress (2): 112/304 kB | 106/471 kB^MProgress (2): 114/304 kB | 106/471 kB^MProgress (2): 114/304 kB | 109/471 kB^MProgress (2): 114/304 kB | 112/471 kB^MProgress (2): 117/304 kB | 112/471 kB^MProgress (2): 117/304 kB | 114/471 kB^MProgress (2): 120/304 kB | 114/471 kB^MProgress (2): 122/304 kB | 114/471 kB^MProgress (2): 122/304 kB | 117/471 kB^MProgress (2): 125/304 kB | 117/471 kB^MProgress (2): 125/304 kB | 120/471 kB^MProgress (2): 125/304 kB | 122/471 kB^MProgress (2): 128/304 kB | 122/471 kB^MProgress (2): 130/304 kB | 122/471 kB^MProgress (2): 130/304 kB | 125/471 kB^MProgress (2): 134/304 kB | 125/471 kB^MProgress (2): 134/304 kB | 128/471 kB^MProgress (2): 136/304 kB | 128/471 kB^MProgress (2): 136/304 kB | 130/471 kB^MProgress (2): 139/304 kB | 130/471 kB^MProgress (2): 142/304 kB | 130/471 kB^MProgress (2): 144/304 kB | 130/471 kB^MProgress (2): 144/304 kB | 134/471 kB^MProgress (2): 147/304 kB | 134/471 kB^MProgress (2): 147/304 kB | 136/471 kB^MProgress (2): 150/304 kB | 136/471 kB^MProgress (2): 150/304 kB | 139/471 kB^MProgress (2): 152/304 kB | 139/471 kB^MProgress (2): 152/304 kB | 142/471 kB^MProgress (2): 155/304 kB | 142/471 kB^MProgress (2): 155/304 kB | 144/471 kB^MProgress (2): 158/304 kB | 144/471 kB^MProgress (2): 158/304 kB | 147/471 kB^MProgress (2): 161/304 kB | 147/471 kB^MProgress (2): 161/304 kB | 150/471 kB^MProgress (2): 163/304 kB | 150/471 kB^MProgress (2): 167/304 kB | 150/471 kB^MProgress (2): 167/304 kB | 152/471 kB^MProgress (2): 167/304 kB | 155/471 kB^MProgress (2): 169/304 kB | 155/471 kB^MProgress (2): 169/304 kB | 158/471 kB^MProgress (2): 172/304 kB | 158/471 kB^MProgress (2): 172/304 kB | 161/471 kB^MProgress (2): 175/304 kB | 161/471 kB^MProgress (2): 175/304 kB | 163/471 kB^MProgress (2): 177/304 kB | 163/471 kB^MProgress (2): 177/304 kB | 167/471 kB^MProgress (2): 180/304 kB | 167/471 kB^MProgress (2): 180/304 kB | 169/471 kB^MProgress (2): 183/304 kB | 169/471 kB^MProgress (2): 183/304 kB | 172/471 kB^MProgress (2): 185/304 kB | 172/471 kB^MProgress (2): 185/304 kB | 175/471 kB^MProgress (2): 188/304 kB | 175/471 kB^MProgress (2): 188/304 kB | 177/471 kB^MProgress (2): 191/304 kB | 177/471 kB^MProgress (2): 193/304 kB | 177/471 kB^MProgress (2): 193/304 kB | 180/471 kB^MProgress (2): 196/304 kB | 180/471 kB^MProgress (2): 196/304 kB | 183/471 kB^MProgress (2): 199/304 kB | 183/471 kB^MProgress (2): 199/304 kB | 185/471 kB^MProgress (2): 202/304 kB | 185/471 kB^MProgress (2): 202/304 kB | 188/471 kB^MProgress (2): 205/304 kB | 188/471 kB^MProgress (2): 205/304 kB | 191/471 kB^MProgress (2): 207/304 kB | 191/471 kB^MProgress (2): 207/304 kB | 193/471 kB^MProgress (2): 210/304 kB | 193/471 kB^MProgress (2): 210/304 kB | 196/471 kB^MProgress (2): 213/304 kB | 196/471 kB^MProgress (2): 213/304 kB | 199/471 kB^MProgress (2): 215/304 kB | 199/471 kB^MProgress (2): 215/304 kB | 202/471 kB^MProgress (2): 218/304 kB | 202/471 kB^MProgress (2): 218/304 kB | 205/471 kB^MProgress (2): 221/304 kB | 205/471 kB^MProgress (2): 221/304 kB | 207/471 kB^MProgress (2): 223/304 kB | 207/471 kB^MProgress (2): 223/304 kB | 210/471 kB^MProgress (2): 226/304 kB | 210/471 kB^MProgress (2): 226/304 kB | 213/471 kB^MProgress (2): 229/304 kB | 213/471 kB^MProgress (2): 229/304 kB | 215/471 kB^MProgress (2): 232/304 kB | 215/471 kB^MProgress (2): 232/304 kB | 218/471 kB^MProgress (2): 235/304 kB | 218/471 kB^MProgress (2): 235/304 kB | 221/471 kB^MProgress (2): 237/304 kB | 221/471 kB^MProgress (2): 237/304 kB | 223/471 kB^MProgress (2): 240/304 kB | 223/471 kB^MProgress (2): 240/304 kB | 226/471 kB^MProgress (2): 243/304 kB | 226/471 kB^MProgress (2): 245/304 kB | 226/471 kB^MProgress (2): 245/304 kB | 229/471 kB^MProgress (2): 248/304 kB | 229/471 kB^MProgress (2): 248/304 kB | 232/471 kB^MProgress (2): 251/304 kB | 232/471 kB^MProgress (2): 251/304 kB | 235/471 kB^MProgress (2): 253/304 kB | 235/471 kB^MProgress (2): 253/304 kB | 237/471 kB^MProgress (2): 256/304 kB | 237/471 kB^MProgress (2): 256/304 kB | 240/471 kB^MProgress (2): 259/304 kB | 240/471 kB^MProgress (2): 259/304 kB | 243/471 kB^MProgress (2): 262/304 kB | 243/471 kB^MProgress (2): 262/304 kB | 245/471 kB^MProgress (2): 264/304 kB | 245/471 kB^MProgress (2): 264/304 kB | 248/471 kB^MProgress (2): 267/304 kB | 248/471 kB^MProgress (2): 267/304 kB | 251/471 kB^MProgress (2): 270/304 kB | 251/471 kB^MProgress (2): 270/304 kB | 253/471 kB^MProgress (2): 272/304 kB | 253/471 kB^MProgress (2): 272/304 kB | 256/471 kB^MProgress (2): 275/304 kB | 256/471 kB^MProgress (2): 275/304 kB | 259/471 kB^MProgress (2): 278/304 kB | 259/471 kB^MProgress (2): 278/304 kB | 262/471 kB^MProgress (2): 280/304 kB | 262/471 kB^MProgress (2): 280/304 kB | 264/471 kB^MProgress (2): 283/304 kB | 264/471 kB^MProgress (2): 283/304 kB | 267/471 kB^MProgress (2): 286/304 kB | 267/471 kB^MProgress (2): 286/304 kB | 270/471 kB^MProgress (2): 288/304 kB | 270/471 kB^MProgress (2): 288/304 kB | 272/471 kB^MProgress (2): 291/304 kB | 272/471 kB^MProgress (2): 291/304 kB | 275/471 kB^MProgress (2): 294/304 kB | 275/471 kB^MProgress (2): 294/304 kB | 278/471 kB^MProgress (2): 297/304 kB | 278/471 kB^MProgress (2): 297/304 kB | 280/471 kB^MProgress (2): 300/304 kB | 280/471 kB^MProgress (2): 300/304 kB | 283/471 kB^MProgress (2): 302/304 kB | 283/471 kB^MProgress (2): 302/304 kB | 286/471 kB^MProgress (2): 304 kB | 286/471 kB    ^MProgress (2): 304 kB | 288/471 kB^MProgress (2): 304 kB | 291/471 kB^MProgress (2): 304 kB | 294/471 kB^MProgress (2): 304 kB | 297/471 kB^MProgress (2): 304 kB | 300/471 kB^MProgress (2): 304 kB | 302/471 kB^MProgress (2): 304 kB | 305/471 kB^MProgress (2): 304 kB | 308/471 kB^MProgress (2): 304 kB | 310/471 kB^MProgress (2): 304 kB | 313/471 kB^MProgress (2): 304 kB | 316/471 kB^MProgress (2): 304 kB | 318/471 kB^MProgress (2): 304 kB | 321/471 kB^MProgress (2): 304 kB | 324/471 kB^MProgress (2): 304 kB | 326/471 kB^MProgress (2): 304 kB | 330/471 kB^MProgress (2): 304 kB | 332/471 kB^MProgress (2): 304 kB | 335/471 kB^MProgress (2): 304 kB | 338/471 kB^MProgress (2): 304 kB | 340/471 kB^MProgress (2): 304 kB | 343/471 kB^MProgress (2): 304 kB | 346/471 kB^MProgress (2): 304 kB | 348/471 kB^MProgress (2): 304 kB | 351/471 kB^MProgress (2): 304 kB | 354/471 kB^MProgress (2): 304 kB | 357/471 kB^MProgress (2): 304 kB | 359/471 kB^MProgress (2): 304 kB | 362/471 kB^MProgress (2): 304 kB | 365/471 kB^MProgress (2): 304 kB | 368/471 kB^MProgress (2): 304 kB | 371/471 kB^MProgress (2): 304 kB | 373/471 kB^MProgress (2): 304 kB | 376/471 kB^MProgress (2): 304 kB | 379/471 kB^MProgress (2): 304 kB | 381/471 kB^MProgress (2): 304 kB | 384/471 kB^MProgress (2): 304 kB | 387/471 kB^MProgress (2): 304 kB | 389/471 kB^MProgress (2): 304 kB | 392/471 kB^MProgress (2): 304 kB | 395/471 kB^MProgress (2): 304 kB | 397/471 kB^MProgress (2): 304 kB | 400/471 kB^MProgress (2): 304 kB | 403/471 kB^MProgress (2): 304 kB | 405/471 kB^MProgress (2): 304 kB | 408/471 kB^MProgress (2): 304 kB | 411/471 kB^MProgress (2): 304 kB | 413/471 kB^MProgress (2): 304 kB | 417/471 kB^MProgress (2): 304 kB | 419/471 kB^MProgress (2): 304 kB | 422/471 kB^MProgress (2): 304 kB | 425/471 kB^MProgress (2): 304 kB | 427/471 kB^MProgress (2): 304 kB | 430/471 kB^MProgress (2): 304 kB | 433/471 kB^MProgress (2): 304 kB | 435/471 kB^MProgress (2): 304 kB | 438/471 kB^MProgress (2): 304 kB | 441/471 kB^MProgress (2): 304 kB | 443/471 kB^MProgress (2): 304 kB | 446/471 kB^MProgress (2): 304 kB | 449/471 kB^MProgress (2): 304 kB | 452/471 kB^MProgress (2): 304 kB | 455/471 kB^MProgress (2): 304 kB | 457/471 kB^MProgress (2): 304 kB | 460/471 kB^MProgress (2): 304 kB | 463/471 kB^MProgress (2): 304 kB | 466/471 kB^MProgress (2): 304 kB | 468/471 kB^MProgress (2): 304 kB | 471 kB    ^M                             ^MDownloaded from jcenter-snapshots: https://jcenter.bintray.com/ch/qos/logback/logback-core/1.1.7/logback-core-1.1.7.jar (471 kB at 2.7 MB/s)
``
[log-before.txt](https://github.com/EBISPOT/OLS/files/8965129/log-before.txt)
[log-after.txt](https://github.com/EBISPOT/OLS/files/8965130/log-after.txt)
`