### PR TITLE
Docs: Add link to ols-py, Python OLS client

### DIFF
--- a/ols-web/src/main/asciidoc/developer.adoc
+++ b/ols-web/src/main/asciidoc/developer.adoc
@@ -10,6 +10,7 @@
 === OLS community
 * Java client to OLS developed by the EMBL-EBI PRIDE team https://github.com/PRIDE-Utilities/ols-client
 * R client to the OLS https://github.com/lgatto/rols/
+* Python client to the OLS https://github.com/ahida-development/ols-py
 
 === OLS javascript widgets
 * OLS autocomplete https://www.npmjs.com/package/ols-autocomplete


### PR DESCRIPTION
As part of developing https://ahida.sydney.edu.au/ and https://omia.org/home/ I've been putting together a [Python client for OLS](https://github.com/ahida-development/ols-py). It's still somewhat early in development, and not all endpoints have been implemented yet, but hopefully it's useful for any future devs wanting to work with the OLS in Python.